### PR TITLE
Change link to webapp source

### DIFF
--- a/app/xkcdref/webapp/templates/index.html
+++ b/app/xkcdref/webapp/templates/index.html
@@ -35,7 +35,7 @@
 
             <p>This webapp is open source!</p>
 
-            <p><a href="https://github.com/JeremySimpson/redditbot" class="btn btn-outline">View on Github.com</a></p>
+            <p><a href="https://github.com/JeremySimpson/xkcdref" class="btn btn-outline">View on Github.com</a></p>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
The text says "This webapp is open source!" Also there's already a link to the bot in the footer. 